### PR TITLE
DB schema update: `done_at` renamed to `ended_at`, added `end_status`

### DIFF
--- a/lib/queuetopia.ex
+++ b/lib/queuetopia.ex
@@ -214,9 +214,15 @@ defmodule Queuetopia do
         Queuetopia.Queue.paginate_jobs(@repo, page_size, page_number, opts)
       end
 
-      @spec abort_job(Job.t(), error :: any) :: {:ok, any} | {:error, any}
-      def abort_job(%Job{} = job, error \\ nil) do
-        Queuetopia.Queue.abort_job(@repo, job, error)
+      @spec abort_job(Job.t()) :: :ok | {:error, any}
+      def abort_job(%Job{} = job) do
+        scheduler_pid = Process.whereis(scheduler())
+
+        if is_pid(scheduler_pid) do
+          Queuetopia.Scheduler.abort_job(scheduler_pid, job)
+        else
+          {:error, "#{inspect(__MODULE__)} is down"}
+        end
       end
 
       def handle_event(:new_incoming_job) do

--- a/lib/queuetopia.ex
+++ b/lib/queuetopia.ex
@@ -214,6 +214,11 @@ defmodule Queuetopia do
         Queuetopia.Queue.paginate_jobs(@repo, page_size, page_number, opts)
       end
 
+      @spec abort_job(Job.t(), error :: any) :: {:ok, any} | {:error, any}
+      def abort_job(%Job{} = job, error \\ nil) do
+        Queuetopia.Queue.abort_job(@repo, job, error)
+      end
+
       def handle_event(:new_incoming_job) do
         listen(:new_incoming_job)
       end

--- a/lib/queuetopia/migrations.ex
+++ b/lib/queuetopia/migrations.ex
@@ -2,7 +2,7 @@ defmodule Queuetopia.Migrations do
   use Ecto.Migration
 
   @initial_version 0
-  @current_version 5
+  @current_version 6
   def up(opts \\ []) when is_list(opts) do
     from_version = Keyword.get(opts, :from_version, @initial_version) |> Kernel.+(1)
     to_version = Keyword.get(opts, :to_version, @current_version)

--- a/lib/queuetopia/migrations/v6.ex
+++ b/lib/queuetopia/migrations/v6.ex
@@ -14,21 +14,19 @@ defmodule Queuetopia.Migrations.V6 do
       add(:end_status, :string, null: true)
     end
 
-    set_end_status_to_success =
-      """
-      UPDATE queuetopia_jobs
-      SET end_status = 'success'
-      WHERE ended_at IS NOT NULL AND error IS NULL;
-      """
+    set_end_status_to_success = """
+    UPDATE queuetopia_jobs
+    SET end_status = 'success'
+    WHERE ended_at IS NOT NULL AND error IS NULL;
+    """
 
     execute(set_end_status_to_success)
 
-    set_end_status_to_max_attempts_reached =
-      """
-      UPDATE queuetopia_jobs
-      SET ended_at = attempted_at, end_status = 'max_attempts_reached'
-      WHERE ended_at IS NULL AND attempts >= max_attempts;
-      """
+    set_end_status_to_max_attempts_reached = """
+    UPDATE queuetopia_jobs
+    SET ended_at = attempted_at, end_status = 'max_attempts_reached'
+    WHERE ended_at IS NULL AND attempts >= max_attempts;
+    """
 
     execute(set_end_status_to_max_attempts_reached)
   end

--- a/lib/queuetopia/migrations/v6.ex
+++ b/lib/queuetopia/migrations/v6.ex
@@ -5,16 +5,44 @@ defmodule Queuetopia.Migrations.V6 do
 
   def up do
     rename(table(:queuetopia_jobs), :done_at, to: :ended_at)
-    rename(index(:queuetopia_jobs, [:ended_at], name: "queuetopia_jobs_done_at_index"), to: "queuetopia_jobs_ended_at_index")
+
+    rename(index(:queuetopia_jobs, [:ended_at], name: "queuetopia_jobs_done_at_index"),
+      to: "queuetopia_jobs_ended_at_index"
+    )
 
     alter table(:queuetopia_jobs) do
       add(:end_status, :string, null: true)
     end
+
+    max_attempts_reached =
+      """
+      UPDATE queuetopia_jobs
+      SET ended_at = attempted_at
+      WHERE ended_at IS NULL AND attempts >= max_attempts;
+      """
+
+    execute(max_attempts_reached)
+
+    end_status_query =
+      """
+      UPDATE queuetopia_jobs
+      SET end_status =
+        CASE
+          WHEN error IS NULL THEN 'success'
+          ELSE 'failed'
+        END
+      WHERE ended_at IS NOT NULL;
+      """
+
+    execute(end_status_query)
   end
 
   def down do
     rename(table(:queuetopia_jobs), :ended_at, to: :done_at)
-    rename(index(:queuetopia_jobs, [:done_at], name: "queuetopia_jobs_ended_at_index"), to: "queuetopia_jobs_done_at_index")
+
+    rename(index(:queuetopia_jobs, [:done_at], name: "queuetopia_jobs_ended_at_index"),
+      to: "queuetopia_jobs_done_at_index"
+    )
 
     alter table(:queuetopia_jobs) do
       remove(:end_status)

--- a/lib/queuetopia/migrations/v6.ex
+++ b/lib/queuetopia/migrations/v6.ex
@@ -1,0 +1,23 @@
+defmodule Queuetopia.Migrations.V6 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up do
+    rename(table(:queuetopia_jobs), :done_at, to: :ended_at)
+    rename(index(:queuetopia_jobs, [:ended_at], name: "queuetopia_jobs_done_at_index"), to: "queuetopia_jobs_ended_at_index")
+
+    alter table(:queuetopia_jobs) do
+      add(:end_status, :string, null: true)
+    end
+  end
+
+  def down do
+    rename(table(:queuetopia_jobs), :ended_at, to: :done_at)
+    rename(index(:queuetopia_jobs, [:done_at], name: "queuetopia_jobs_ended_at_index"), to: "queuetopia_jobs_done_at_index")
+
+    alter table(:queuetopia_jobs) do
+      remove(:end_status)
+    end
+  end
+end

--- a/lib/queuetopia/queue.ex
+++ b/lib/queuetopia/queue.ex
@@ -266,6 +266,7 @@ defmodule Queuetopia.Queue do
       attempted_at: utc_now,
       attempted_by: Atom.to_string(Node.self()),
       ended_at: utc_now,
+      end_status: "max_attempts_reached",
       error: error
     })
     |> repo.update!()

--- a/lib/queuetopia/queue.ex
+++ b/lib/queuetopia/queue.ex
@@ -244,7 +244,7 @@ defmodule Queuetopia.Queue do
   end
 
   @doc false
-  @spec persist_result!(module, Job.t(), {:error, any} | :ok | {:ok, any} | :abort) :: Job.t()
+  @spec persist_result!(module, Job.t(), {:error, any} | :ok | {:ok, any} | :aborted) :: Job.t()
 
   def persist_result!(repo, %Job{} = job, {:ok, _res}), do: persist_success!(repo, job)
   def persist_result!(repo, %Job{} = job, :ok), do: persist_success!(repo, job)

--- a/lib/queuetopia/queue.ex
+++ b/lib/queuetopia/queue.ex
@@ -108,7 +108,7 @@ defmodule Queuetopia.Queue do
   """
   @spec processable_now?(Job.t()) :: boolean
   def processable_now?(%Job{} = job) do
-    not done?(job) and scheduled_for_now?(job)
+    not done?(job) and not skipped?(job) and scheduled_for_now?(job)
   end
 
   @doc """
@@ -118,6 +118,15 @@ defmodule Queuetopia.Queue do
   @spec done?(Job.t()) :: boolean
   def done?(%Job{} = job) do
     not is_nil(job.done_at)
+  end
+
+  @doc """
+  Returns true if a job is skipped.
+  Otherwise, returns false.
+  """
+  @spec skipped?(Job.t()) :: boolean
+  def skipped?(%Job{} = job) do
+    job.attempts >= job.max_attempts
   end
 
   @doc """
@@ -165,6 +174,7 @@ defmodule Queuetopia.Queue do
       Job
       |> where([j], j.scope == ^scope)
       |> where([j], is_nil(j.done_at))
+      |> where([j], j.attempts < j.max_attempts)
       |> where([j], j.queue not in subquery(locked_queues))
       |> where([j], j.queue not in subquery(blocked_queues))
       |> where_immediately_executable_job.()
@@ -191,6 +201,7 @@ defmodule Queuetopia.Queue do
       |> where([j], j.queue == ^queue)
       |> where([j], j.scope == ^scope)
       |> where([j], is_nil(j.done_at))
+      |> where([j], j.attempts < j.max_attempts)
       |> order_by(asc: :scheduled_at, asc: :sequence)
       |> limit(1)
       |> repo.one()
@@ -212,10 +223,12 @@ defmodule Queuetopia.Queue do
       job = repo.get(Job, id)
 
       with {:done?, false} <- {:done?, done?(job)},
+           {:skipped?, false} <- {:skipped?, skipped?(job)},
            {:scheduled_for_now?, true} <- {:scheduled_for_now?, scheduled_for_now?(job)} do
         {:ok, job}
       else
         {:done?, true} -> {:error, "already done"}
+        {:skipped?, true} -> {:error, "skipped"}
         {:scheduled_for_now?, false} -> {:error, "scheduled for later"}
       end
     end)

--- a/lib/queuetopia/queue.ex
+++ b/lib/queuetopia/queue.ex
@@ -256,7 +256,7 @@ defmodule Queuetopia.Queue do
     do: persist_failure!(repo, job, inspect(unexpected_response))
 
   defp persist_failure!(repo, %Job{attempts: attempts, max_attempts: max_attempts} = job, error)
-    when attempts + 1 >= max_attempts do
+       when attempts + 1 >= max_attempts do
     utc_now = DateTime.utc_now() |> DateTime.truncate(:second)
     performer = resolve_performer(job)
 
@@ -266,7 +266,7 @@ defmodule Queuetopia.Queue do
       attempted_at: utc_now,
       attempted_by: Atom.to_string(Node.self()),
       ended_at: utc_now,
-      error: error,
+      error: error
     })
     |> repo.update!()
     |> tap(&performer.handle_failed_job!/1)

--- a/lib/queuetopia/queue/job.ex
+++ b/lib/queuetopia/queue/job.ex
@@ -2,7 +2,15 @@ defmodule Queuetopia.Queue.Job do
   @moduledoc false
 
   use Ecto.Schema
-  import Ecto.Changeset, only: [cast: 3, put_change: 3, validate_number: 3, validate_required: 2]
+
+  import Ecto.Changeset,
+    only: [
+      cast: 3,
+      put_change: 3,
+      validate_number: 3,
+      validate_required: 2,
+      validate_inclusion: 3
+    ]
 
   @type t :: %__MODULE__{}
   @type option ::
@@ -85,10 +93,18 @@ defmodule Queuetopia.Queue.Job do
   @spec failed_job_changeset(Job.t(), map) :: Ecto.Changeset.t()
   def failed_job_changeset(%__MODULE__{} = job, attrs) when is_map(attrs) do
     job
-    |> cast(attrs, [:attempts, :attempted_at, :attempted_by, :ended_at, :error])
+    |> cast(attrs, [:attempts, :attempted_at, :attempted_by, :ended_at, :end_status, :error])
     |> validate_required_attempt_attributes
+    |> validate_required([:ended_at, :end_status, :error])
+    |> validate_inclusion(:end_status, ["failed", "max_attempts_reached"])
+  end
+
+  @spec aborted_job_changeset(Job.t(), map) :: Ecto.Changeset.t()
+  def aborted_job_changeset(%__MODULE__{} = job, attrs) when is_map(attrs) do
+    job
+    |> cast(attrs, [:ended_at, :error])
     |> validate_required([:ended_at, :error])
-    |> put_change(:end_status, "failed")
+    |> put_change(:end_status, "aborted")
   end
 
   @spec succeeded_job_changeset(Job.t(), map) :: Ecto.Changeset.t()

--- a/lib/queuetopia/queue/job.ex
+++ b/lib/queuetopia/queue/job.ex
@@ -102,7 +102,7 @@ defmodule Queuetopia.Queue.Job do
   @spec aborted_job_changeset(Job.t(), map) :: Ecto.Changeset.t()
   def aborted_job_changeset(%__MODULE__{} = job, attrs) when is_map(attrs) do
     job
-    |> cast(attrs, [:ended_at, :error])
+    |> cast(attrs, [:ended_at])
     |> validate_required([:ended_at])
     |> put_change(:end_status, "aborted")
   end

--- a/lib/queuetopia/queue/job.ex
+++ b/lib/queuetopia/queue/job.ex
@@ -103,7 +103,7 @@ defmodule Queuetopia.Queue.Job do
   def aborted_job_changeset(%__MODULE__{} = job, attrs) when is_map(attrs) do
     job
     |> cast(attrs, [:ended_at, :error])
-    |> validate_required([:ended_at, :error])
+    |> validate_required([:ended_at])
     |> put_change(:end_status, "aborted")
   end
 

--- a/lib/queuetopia/queue/job_queryable.ex
+++ b/lib/queuetopia/queue/job_queryable.ex
@@ -9,8 +9,7 @@ defmodule Queuetopia.Queue.JobQueryable do
 
   defp filter_by_field(queryable, {:available?, true}) do
     queryable
-    |> where([job], is_nil(job.done_at))
-    |> where([job], job.attempts < job.max_attempts)
+    |> where([job], is_nil(job.ended_at))
   end
 
   defp filter_by_field(_queryable, {key, _value}) when key not in @filterable_fields do

--- a/lib/queuetopia/queue/job_queryable.ex
+++ b/lib/queuetopia/queue/job_queryable.ex
@@ -10,6 +10,7 @@ defmodule Queuetopia.Queue.JobQueryable do
   defp filter_by_field(queryable, {:available?, true}) do
     queryable
     |> where([job], is_nil(job.done_at))
+    |> where([job], job.attempts < job.max_attempts)
   end
 
   defp filter_by_field(_queryable, {key, _value}) when key not in @filterable_fields do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Queuetopia.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/annatel/queuetopia"
-  @version "2.5.2"
+  @version "2.6.0"
 
   def project do
     [

--- a/test/queuetopia/queue/job_test.exs
+++ b/test/queuetopia/queue/job_test.exs
@@ -123,7 +123,7 @@ defmodule Queuetopia.Queue.JobTest do
     end
   end
 
-  describe "failed_job_changeset/2" do
+  describe "retry_job_changeset/2" do
     test "only permitted_keys are casted" do
       job = insert!(:job)
 
@@ -136,7 +136,7 @@ defmodule Queuetopia.Queue.JobTest do
           error: "error"
         )
 
-      changeset = Job.failed_job_changeset(job, Map.merge(params, %{new_key: "value"}))
+      changeset = Job.retry_job_changeset(job, Map.merge(params, %{new_key: "value"}))
       changes_keys = changeset.changes |> Map.keys()
 
       assert :attempts in changes_keys
@@ -152,7 +152,7 @@ defmodule Queuetopia.Queue.JobTest do
     test "when required params are missing, returns an invalid changeset" do
       job = insert!(:job)
 
-      changeset = Job.failed_job_changeset(job, %{attempts: nil, scheduled_at: nil})
+      changeset = Job.retry_job_changeset(job, %{attempts: nil, scheduled_at: nil})
 
       refute changeset.valid?
       assert %{attempts: ["can't be blank"]} = errors_on(changeset)
@@ -167,11 +167,82 @@ defmodule Queuetopia.Queue.JobTest do
       job = insert!(:job)
 
       changeset =
-        Job.failed_job_changeset(job, %{
+        Job.retry_job_changeset(job, %{
           attempts: 1,
           attempted_at: utc_now,
           attempted_by: Atom.to_string(Node.self()),
           next_attempt_at: utc_now,
+          error: "error"
+        })
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "failed_job_changeset/2" do
+    test "only permitted_keys are casted" do
+      job = insert!(:job)
+
+      params =
+        params_for(:job,
+          attempts: 6,
+          attempted_at: utc_now(),
+          attempted_by: Atom.to_string(Node.self()),
+          ended_at: utc_now(),
+          error: "error"
+        )
+
+      changeset = Job.failed_job_changeset(job, Map.merge(params, %{new_key: "value"}))
+      changes_keys = changeset.changes |> Map.keys()
+
+      assert :attempts in changes_keys
+      assert :attempted_at in changes_keys
+      assert :attempted_by in changes_keys
+      assert :ended_at in changes_keys
+      assert :end_status in changes_keys
+      assert :error in changes_keys
+      assert Enum.count(changes_keys) == 6
+
+      refute :new_key in changes_keys
+    end
+
+    test "when required params are missing, returns an invalid changeset" do
+      job = insert!(:job)
+
+      changeset = Job.failed_job_changeset(job, %{attempts: nil, scheduled_at: nil})
+
+      refute changeset.valid?
+      assert %{attempts: ["can't be blank"]} = errors_on(changeset)
+      assert %{attempted_at: ["can't be blank"]} = errors_on(changeset)
+      assert %{attempted_by: ["can't be blank"]} = errors_on(changeset)
+      assert %{ended_at: ["can't be blank"]} = errors_on(changeset)
+      assert %{error: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "fills the end_status field by 'failed'" do
+      job = insert!(:job)
+
+      changeset =
+        Job.failed_job_changeset(job, %{
+          attempts: 1,
+          attempted_at: utc_now(),
+          attempted_by: Atom.to_string(Node.self()),
+          ended_at: utc_now(),
+          error: "error"
+        })
+
+      assert changeset.changes.end_status == "failed"
+    end
+
+    test "when params are valid, return a valid changeset" do
+      job = insert!(:job)
+
+      changeset =
+        Job.failed_job_changeset(job, %{
+          attempts: 1,
+          attempted_at: utc_now(),
+          attempted_by: Atom.to_string(Node.self()),
+          ended_at: utc_now(),
           error: "error"
         })
 
@@ -188,7 +259,7 @@ defmodule Queuetopia.Queue.JobTest do
           attempts: 6,
           attempted_at: utc_now(),
           attempted_by: Atom.to_string(Node.self()),
-          done_at: utc_now()
+          ended_at: utc_now()
         )
 
       changeset = Job.succeeded_job_changeset(job, Map.merge(params, %{new_key: "value"}))
@@ -197,8 +268,9 @@ defmodule Queuetopia.Queue.JobTest do
       assert :attempts in changes_keys
       assert :attempted_at in changes_keys
       assert :attempted_by in changes_keys
-      assert :done_at in changes_keys
-      assert Enum.count(changes_keys) == 4
+      assert :ended_at in changes_keys
+      assert :end_status in changes_keys
+      assert Enum.count(changes_keys) == 5
 
       refute :new_key in changes_keys
     end
@@ -211,7 +283,7 @@ defmodule Queuetopia.Queue.JobTest do
       assert %{attempts: ["can't be blank"]} = errors_on(changeset)
       assert %{attempted_at: ["can't be blank"]} = errors_on(changeset)
       assert %{attempted_by: ["can't be blank"]} = errors_on(changeset)
-      assert %{done_at: ["can't be blank"]} = errors_on(changeset)
+      assert %{ended_at: ["can't be blank"]} = errors_on(changeset)
     end
 
     test "nillifies error field" do
@@ -222,12 +294,28 @@ defmodule Queuetopia.Queue.JobTest do
           attempts: 6,
           attempted_at: utc_now(),
           attempted_by: Atom.to_string(Node.self()),
-          done_at: utc_now()
+          ended_at: utc_now()
         )
 
       changeset = Job.succeeded_job_changeset(job, params)
 
       assert is_nil(changeset.changes.error)
+    end
+
+    test "fills the end_status field by 'success'" do
+      job = insert!(:job)
+
+      params =
+        params_for(:job,
+          attempts: 6,
+          attempted_at: utc_now(),
+          attempted_by: Atom.to_string(Node.self()),
+          ended_at: utc_now()
+        )
+
+      changeset = Job.succeeded_job_changeset(job, params)
+
+      assert changeset.changes.end_status == "success"
     end
 
     test "when params are valid, return a valid changeset" do
@@ -239,7 +327,7 @@ defmodule Queuetopia.Queue.JobTest do
           attempts: 1,
           attempted_at: utc_now,
           attempted_by: Atom.to_string(Node.self()),
-          done_at: utc_now
+          ended_at: utc_now
         })
 
       assert changeset.valid?

--- a/test/queuetopia/queue_test.exs
+++ b/test/queuetopia/queue_test.exs
@@ -347,6 +347,16 @@ defmodule Queuetopia.QueueTest do
       assert job.error == "\"unexpected_response\""
     end
 
+    test "when a job aborted, persists the job as aborted and record the ended_at and end_status" do
+      job = insert!(:job)
+
+      _ = Queue.persist_result!(TestRepo, job, :aborted)
+
+      %Job{} = job = TestRepo.reload(job)
+      refute is_nil(job.ended_at)
+      assert job.end_status == "aborted"
+    end
+
     test "when handle_failed_job/1 is defined by the performer" do
       %{id: id} =
         job =
@@ -664,40 +674,6 @@ defmodule Queuetopia.QueueTest do
       end)
 
       assert Queue.list_jobs(TestRepo, search_query: "wrong") == []
-    end
-  end
-
-  describe "abort_job/3" do
-    test "when aborts the ended job, returns error" do
-      job = insert!(:ended_job)
-
-      assert {:error, "already ended"} = Queue.abort_job(TestRepo, job)
-    end
-
-    test "when aborts the not ended job, aborts the job and record the ended_at and the end_status" do
-      job = insert!(:job)
-
-      assert {:ok, %Job{}} = Queue.abort_job(TestRepo, job)
-
-      %Job{} = job = TestRepo.reload(job)
-      refute is_nil(job.ended_at)
-      assert job.end_status == "aborted"
-    end
-
-    test "when aborts the locked not ended job, aborts the job and removes the lock" do
-      %Job{id: id, queue: queue, scope: scope} = job = insert!(:job, timeout: 1_000)
-
-      assert {:ok, %Job{id: ^id}} = Queue.fetch_job(TestRepo, job)
-
-      assert %Lock{} = TestRepo.get_by(Lock, scope: scope, queue: queue)
-
-      assert {:ok, %Job{end_status: "aborted"}} = Queue.abort_job(TestRepo, job)
-
-      assert is_nil(TestRepo.get_by(Lock, scope: scope, queue: queue))
-    end
-
-    test "when aborts the perfoming job, ..." do
-      # TODO
     end
   end
 

--- a/test/queuetopia/queue_test.exs
+++ b/test/queuetopia/queue_test.exs
@@ -381,7 +381,11 @@ defmodule Queuetopia.QueueTest do
           next_attempt_at: next_attempt_at
         } = TestRepo.reload(job)
 
-        assert :eq = DateTime.compare(next_attempt_at, DateTime.add(attempted_at, backoff, :millisecond))
+        assert :eq =
+                 DateTime.compare(
+                   next_attempt_at,
+                   DateTime.add(attempted_at, backoff, :millisecond)
+                 )
       end)
     end
 
@@ -423,7 +427,11 @@ defmodule Queuetopia.QueueTest do
         next_attempt_at: next_attempt_at
       } = TestRepo.reload(job)
 
-      assert :eq = DateTime.compare(next_attempt_at, DateTime.add(attempted_at, max_backoff, :millisecond))
+      assert :eq =
+               DateTime.compare(
+                 next_attempt_at,
+                 DateTime.add(attempted_at, max_backoff, :millisecond)
+               )
 
       _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
 
@@ -433,7 +441,11 @@ defmodule Queuetopia.QueueTest do
         next_attempt_at: next_attempt_at
       } = TestRepo.reload(job)
 
-      assert :eq = DateTime.compare(next_attempt_at, DateTime.add(attempted_at, max_backoff, :millisecond))
+      assert :eq =
+               DateTime.compare(
+                 next_attempt_at,
+                 DateTime.add(attempted_at, max_backoff, :millisecond)
+               )
     end
   end
 

--- a/test/queuetopia/queue_test.exs
+++ b/test/queuetopia/queue_test.exs
@@ -38,20 +38,8 @@ defmodule Queuetopia.QueueTest do
       assert [] = Queue.list_available_pending_queues(TestRepo, scope)
     end
 
-    test "don't list queues whom jobs are done" do
-      %{queue: _queue_1, scope: scope_1} = insert!(:done_job)
-      assert [] = Queue.list_available_pending_queues(TestRepo, scope_1)
-    end
-
-    test "don't list queues whom jobs are skipped due to reaching the maximum number of attempts" do
-      %{queue: _queue, scope: scope} =
-        insert!(:job,
-          scheduled_at: utc_now() |> add(-3600),
-          next_attempt_at: utc_now(),
-          attempts: 5,
-          max_attempts: 5
-        )
-
+    test "don't list queues whom jobs are ended" do
+      %{queue: _queue, scope: scope} = insert!(:ended_job)
       assert [] = Queue.list_available_pending_queues(TestRepo, scope)
     end
 
@@ -89,7 +77,7 @@ defmodule Queuetopia.QueueTest do
 
   describe "get_next_pending_job/2" do
     test "returns the next pending job for a given scoped queue" do
-      %{queue: queue_1, scope: scope_1} = insert!(:done_job)
+      %{queue: queue_1, scope: scope_1} = insert!(:ended_job)
       %{id: id_1} = insert!(:job, queue: queue_1, scope: scope_1)
 
       %{id: id_2, queue: queue_2} = insert!(:job, scope: scope_1)
@@ -158,13 +146,6 @@ defmodule Queuetopia.QueueTest do
 
       assert is_nil(Queue.get_next_pending_job(TestRepo, scope, queue))
     end
-
-    test "when job skipped due to reaching the maximum number of attempts, returns nil" do
-      %Job{queue: queue, scope: scope} =
-        insert!(:job, next_attempt_at: utc_now(), attempts: 20, max_attempts: 20)
-
-      assert is_nil(Queue.get_next_pending_job(TestRepo, scope, queue))
-    end
   end
 
   describe "fetch_job/2" do
@@ -188,17 +169,10 @@ defmodule Queuetopia.QueueTest do
       assert %Lock{id: ^id} = TestRepo.get_by(Lock, scope: scope, queue: queue)
     end
 
-    test "when the job is done" do
-      %Job{queue: queue, scope: scope} = job = insert!(:done_job)
+    test "when the job is ended" do
+      %Job{queue: queue, scope: scope} = job = insert!(:ended_job)
 
-      assert {:error, "already done"} = Queue.fetch_job(TestRepo, job)
-      assert is_nil(TestRepo.get_by(Lock, scope: scope, queue: queue))
-    end
-
-    test "when the job is skipped due to reaching the maximum number of attempts" do
-      %{queue: queue, scope: scope} = job = insert!(:job, attempts: 20, max_attempts: 20)
-
-      assert {:error, "skipped"} = Queue.fetch_job(TestRepo, job)
+      assert {:error, "already ended"} = Queue.fetch_job(TestRepo, job)
       assert is_nil(TestRepo.get_by(Lock, scope: scope, queue: queue))
     end
 
@@ -295,17 +269,19 @@ defmodule Queuetopia.QueueTest do
       _ = Queue.persist_result!(TestRepo, job, :ok)
 
       %Job{
-        done_at: done_at,
+        ended_at: ended_at,
+        end_status: end_status,
         attempted_at: attempted_at,
         attempted_by: attempted_by,
         attempts: attempts
       } = TestRepo.reload(job)
 
-      refute is_nil(done_at)
       refute is_nil(attempted_at)
+      refute is_nil(ended_at)
+      assert end_status == "success"
       assert attempted_by == Atom.to_string(Node.self())
       assert attempts == 1
-      assert done_at == attempted_at
+      assert ended_at == attempted_at
     end
 
     test "when a job succeeded with a result, persists the job as succeeded" do
@@ -314,40 +290,58 @@ defmodule Queuetopia.QueueTest do
       _ = Queue.persist_result!(TestRepo, job, {:ok, :done})
 
       %Job{
-        done_at: done_at,
+        ended_at: ended_at,
+        end_status: end_status,
         attempted_at: attempted_at,
         attempted_by: attempted_by,
         attempts: attempts
       } = TestRepo.reload(job)
 
-      refute is_nil(done_at)
       refute is_nil(attempted_at)
+      refute is_nil(ended_at)
+      assert end_status == "success"
       assert attempted_by == Atom.to_string(Node.self())
       assert attempts == 1
-      assert done_at == attempted_at
+      assert ended_at == attempted_at
     end
 
-    test "when a job failed, persists the job as failed and record the error" do
+    test "when a job failed and max_attempts is not reached, persists the job and record the error and next_attempt_at" do
       job = insert!(:failure_job)
 
       _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
 
       %Job{} = job = TestRepo.reload(job)
-      assert job.done_at == nil
-      refute job.attempted_at == nil
+      refute is_nil(job.attempted_at)
+      refute is_nil(job.next_attempt_at)
+      assert is_nil(job.ended_at)
       assert job.attempted_by == Atom.to_string(Node.self())
       assert job.attempts == 1
       assert job.error == "error"
     end
 
-    test "when a job returns an unexpected_response, persists the job as failed and record the response" do
+    test "when a job failed and max_attempts is reached, persists the job as failed and record the error" do
+      job = insert!(:failure_job, attempts: 9, max_attempts: 10)
+
+      _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
+
+      %Job{} = job = TestRepo.reload(job)
+      refute is_nil(job.ended_at)
+      refute is_nil(job.attempted_at)
+      assert job.attempted_by == Atom.to_string(Node.self())
+      assert job.attempts == 10
+      assert job.error == "error"
+      assert job.end_status == "failed"
+    end
+
+    test "when a job returns an unexpected_response, persists the job and record the error and the response" do
       job = insert!(:failure_job)
 
       _ = Queue.persist_result!(TestRepo, job, "unexpected_response")
 
       %Job{} = job = TestRepo.reload(job)
-      assert job.done_at == nil
-      refute job.attempted_at == nil
+      refute is_nil(job.attempted_at)
+      refute is_nil(job.next_attempt_at)
+      assert is_nil(job.ended_at)
       assert job.attempted_by == Atom.to_string(Node.self())
       assert job.attempts == 1
       assert job.error == "\"unexpected_response\""
@@ -363,12 +357,12 @@ defmodule Queuetopia.QueueTest do
       _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
 
       %Job{} = job = TestRepo.reload(job)
-      assert job.done_at == nil
+      assert job.ended_at == nil
       refute job.attempted_at == nil
       assert job.attempted_by == Atom.to_string(Node.self())
       assert job.attempts == 1
 
-      assert_receive {:job, %Job{id: ^id, done_at: nil, attempted_at: %DateTime{}, attempts: 1}},
+      assert_receive {:job, %Job{id: ^id, ended_at: nil, attempted_at: %DateTime{}, attempts: 1}},
                      100
     end
 
@@ -382,7 +376,7 @@ defmodule Queuetopia.QueueTest do
         Queue.persist_result!(TestRepo, job, {:error, "error"})
 
         %Job{
-          done_at: nil,
+          ended_at: nil,
           attempted_at: attempted_at,
           next_attempt_at: next_attempt_at
         } = TestRepo.reload(job)
@@ -424,7 +418,7 @@ defmodule Queuetopia.QueueTest do
       _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
 
       %Job{
-        done_at: nil,
+        ended_at: nil,
         attempted_at: attempted_at,
         next_attempt_at: next_attempt_at
       } = TestRepo.reload(job)
@@ -434,7 +428,7 @@ defmodule Queuetopia.QueueTest do
       _ = Queue.persist_result!(TestRepo, job, {:error, "error"})
 
       %Job{
-        done_at: nil,
+        ended_at: nil,
         attempted_at: attempted_at,
         next_attempt_at: next_attempt_at
       } = TestRepo.reload(job)
@@ -444,23 +438,18 @@ defmodule Queuetopia.QueueTest do
   end
 
   describe "processable_now?/1" do
-    test "when the job is processable now" do
+    test "when the job is not ended and processable now" do
       job = insert!(:job)
       assert Queue.processable_now?(job)
     end
 
-    test "when the job is done" do
-      job = insert!(:done_job)
-      refute Queue.processable_now?(job)
-    end
-
-    test "when the job is skipped due to reaching the maximum number of attempts" do
-      job = insert!(:job, attempts: 10, max_attempts: 10)
-      refute Queue.processable_now?(job)
-    end
-
-    test "when the job is scheduled for later" do
+    test "when the job is not ended and scheduled for later" do
       job = insert!(:job, scheduled_at: utc_now() |> add(3600, :second))
+      refute Queue.processable_now?(job)
+    end
+
+    test "when the job is ended" do
+      job = insert!(:ended_job)
       refute Queue.processable_now?(job)
     end
   end
@@ -469,23 +458,28 @@ defmodule Queuetopia.QueueTest do
     test "when the job is not done" do
       job = insert!(:job)
       refute Queue.done?(job)
+      assert is_nil(job.ended_at)
     end
 
     test "when the job is done" do
       job = insert!(:done_job)
       assert Queue.done?(job)
+      refute is_nil(job.ended_at)
+      assert job.end_status == "success"
     end
   end
 
-  describe "skipped?/1" do
-    test "when the job is not skipped" do
+  describe "ended?/1" do
+    test "when the job is not ended" do
       job = insert!(:job)
-      refute Queue.skipped?(job)
+      refute Queue.ended?(job)
+      assert is_nil(job.ended_at)
     end
 
-    test "when the maximum number of attempts reached" do
-      job = insert!(:job, attempts: 10, max_attempts: 10)
-      assert Queue.skipped?(job)
+    test "when the job is done" do
+      job = insert!(:ended_job)
+      assert Queue.ended?(job)
+      refute is_nil(job.ended_at)
     end
   end
 
@@ -560,12 +554,7 @@ defmodule Queuetopia.QueueTest do
     end
 
     test "filters" do
-      insert!(:job, done_at: utc_now())
-
-      assert %{data: [], total: 0} =
-               Queue.paginate_jobs(TestRepo, 100, 1, filters: [available?: true])
-
-      insert!(:job, attempts: 3, max_attempts: 3)
+      insert!(:job, ended_at: utc_now())
 
       assert %{data: [], total: 0} =
                Queue.paginate_jobs(TestRepo, 100, 1, filters: [available?: true])
@@ -626,11 +615,7 @@ defmodule Queuetopia.QueueTest do
     end
 
     test "filters" do
-      insert!(:job, done_at: utc_now())
-
-      assert Queue.list_jobs(TestRepo, filters: [available?: true]) == []
-
-      insert!(:job, attempts: 1, max_attempts: 1)
+      insert!(:job, ended_at: utc_now())
 
       assert Queue.list_jobs(TestRepo, filters: [available?: true]) == []
 

--- a/test/queuetopia/queue_test.exs
+++ b/test/queuetopia/queue_test.exs
@@ -43,18 +43,6 @@ defmodule Queuetopia.QueueTest do
       assert [] = Queue.list_available_pending_queues(TestRepo, scope)
     end
 
-    test "don't list queues whom jobs reached the maximum number of attempts" do
-      %{queue: _queue, scope: scope} =
-        insert!(:job,
-          scheduled_at: utc_now() |> add(-3600),
-          next_attempt_at: utc_now(),
-          attempts: 5,
-          max_attempts: 5
-        )
-
-      assert [] = Queue.list_available_pending_queues(TestRepo, scope)
-    end
-
     test "when limit is given, returns only the specified number of rows from the result set" do
       %{queue: queue, scope: scope} = insert!(:job)
       insert!(:job, queue: queue, scope: scope)
@@ -158,13 +146,6 @@ defmodule Queuetopia.QueueTest do
 
       assert is_nil(Queue.get_next_pending_job(TestRepo, scope, queue))
     end
-
-    test "when max job attempts is reached, returns nil" do
-      %Job{queue: queue, scope: scope} =
-        insert!(:job, next_attempt_at: utc_now(), attempts: 20, max_attempts: 20)
-
-      assert is_nil(Queue.get_next_pending_job(TestRepo, scope, queue))
-    end
   end
 
   describe "fetch_job/2" do
@@ -192,13 +173,6 @@ defmodule Queuetopia.QueueTest do
       %Job{queue: queue, scope: scope} = job = insert!(:ended_job)
 
       assert {:error, "already ended"} = Queue.fetch_job(TestRepo, job)
-      assert is_nil(TestRepo.get_by(Lock, scope: scope, queue: queue))
-    end
-
-    test "when max job attempts is reached, returns error" do
-      %{queue: queue, scope: scope} = job = insert!(:job, attempts: 20, max_attempts: 20)
-
-      assert {:error, "max attempts reached"} = Queue.fetch_job(TestRepo, job)
       assert is_nil(TestRepo.get_by(Lock, scope: scope, queue: queue))
     end
 
@@ -619,11 +593,6 @@ defmodule Queuetopia.QueueTest do
       assert %{data: [], total: 0} =
                Queue.paginate_jobs(TestRepo, 100, 1, filters: [available?: true])
 
-      insert!(:job, attempts: 3, max_attempts: 3)
-
-      assert %{data: [], total: 0} =
-               Queue.paginate_jobs(TestRepo, 100, 1, filters: [available?: true])
-
       %{id: id} = job = insert!(:job)
 
       [
@@ -681,10 +650,6 @@ defmodule Queuetopia.QueueTest do
 
     test "filters" do
       insert!(:job, ended_at: utc_now())
-
-      assert Queue.list_jobs(TestRepo, filters: [available?: true]) == []
-
-      insert!(:job, attempts: 1, max_attempts: 1)
 
       assert Queue.list_jobs(TestRepo, filters: [available?: true]) == []
 

--- a/test/queuetopia/queue_test.exs
+++ b/test/queuetopia/queue_test.exs
@@ -330,7 +330,7 @@ defmodule Queuetopia.QueueTest do
       assert job.attempted_by == Atom.to_string(Node.self())
       assert job.attempts == 10
       assert job.error == "error"
-      assert job.end_status == "failed"
+      assert job.end_status == "max_attempts_reached"
     end
 
     test "when a job returns an unexpected_response, persists the job and record the error and the response" do

--- a/test/queuetopia/scheduler_test.exs
+++ b/test/queuetopia/scheduler_test.exs
@@ -259,7 +259,7 @@ defmodule Queuetopia.SchedulerTest do
     test "a failed job will be retried" do
       scope = TestQueuetopia.scope()
 
-      %{id: failing_job_id, queue: queue} = insert!(:failure_job, scope: scope)
+      %{id: failing_job_id, queue: queue} = insert!(:failure_job, scope: scope, max_attempts: 1000)
 
       start_supervised!(TestQueuetopia)
 
@@ -334,7 +334,7 @@ defmodule Queuetopia.SchedulerTest do
 
       assert %Job{
                id: ^failing_job_id,
-               done_at: nil,
+               ended_at: nil,
                attempted_at: attempted_at,
                attempted_by: attempted_by,
                attempts: attempts,
@@ -365,7 +365,7 @@ defmodule Queuetopia.SchedulerTest do
 
       assert %Job{
                id: ^slow_job_id,
-               done_at: nil,
+               ended_at: nil,
                attempted_at: attempted_at,
                attempted_by: attempted_by,
                attempts: attempts,
@@ -399,7 +399,7 @@ defmodule Queuetopia.SchedulerTest do
 
       assert %Job{
                id: ^raising_job_id,
-               done_at: nil,
+               ended_at: nil,
                attempted_at: attempted_at,
                attempted_by: attempted_by,
                attempts: attempts,

--- a/test/queuetopia/scheduler_test.exs
+++ b/test/queuetopia/scheduler_test.exs
@@ -259,7 +259,8 @@ defmodule Queuetopia.SchedulerTest do
     test "a failed job will be retried" do
       scope = TestQueuetopia.scope()
 
-      %{id: failing_job_id, queue: queue} = insert!(:failure_job, scope: scope, max_attempts: 1000)
+      %{id: failing_job_id, queue: queue} =
+        insert!(:failure_job, scope: scope, max_attempts: 1000)
 
       start_supervised!(TestQueuetopia)
 

--- a/test/queuetopia/test/assertions_test.exs
+++ b/test/queuetopia/test/assertions_test.exs
@@ -75,10 +75,10 @@ defmodule Queuetopia.Test.AssertionsTest do
         )
 
       expected_attributes = %{queue: "queue", scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
+          message: "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
         }
         |> ExUnit.AssertionError.message()
 
@@ -87,10 +87,10 @@ defmodule Queuetopia.Test.AssertionsTest do
       end
 
       expected_attributes = %{action: "action", scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
+          message: "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
         }
         |> ExUnit.AssertionError.message()
 
@@ -107,10 +107,10 @@ defmodule Queuetopia.Test.AssertionsTest do
         )
 
       expected_attributes = %{params: %{"b" => 2}, scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
+          message: "Expected 1 job with attributes #{inspect(expected_attributes)}, got 0."
         }
         |> ExUnit.AssertionError.message()
 
@@ -132,10 +132,10 @@ defmodule Queuetopia.Test.AssertionsTest do
       )
 
       expected_attributes = %{params: %{"a" => 1}, scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 1 job with attributes #{inspect(expected_attributes)}, got 2."
+          message: "Expected 1 job with attributes #{inspect(expected_attributes)}, got 2."
         }
         |> ExUnit.AssertionError.message()
 
@@ -174,10 +174,10 @@ defmodule Queuetopia.Test.AssertionsTest do
       job = insert!(:job, scope: Queuetopia.TestQueuetopia.scope(), params: %{"a" => 1})
 
       expected_attributes = %{queue: job.queue, scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
+          message: "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
         }
         |> ExUnit.AssertionError.message()
 
@@ -186,10 +186,10 @@ defmodule Queuetopia.Test.AssertionsTest do
       end
 
       expected_attributes = %{action: job.action, scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
+          message: "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
         }
         |> ExUnit.AssertionError.message()
 
@@ -198,10 +198,10 @@ defmodule Queuetopia.Test.AssertionsTest do
       end
 
       expected_attributes = %{params: job.params, scope: job.scope}
+
       message =
         %ExUnit.AssertionError{
-          message:
-            "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
+          message: "Expected 0 job with attributes #{inspect(expected_attributes)}, got 1."
         }
         |> ExUnit.AssertionError.message()
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -42,10 +42,16 @@ defmodule Queuetopia.Factory do
     |> struct!(attrs)
   end
 
+  def build(:ended_job, attrs) do
+    job = build(:job, attrs)
+
+    %{job | ended_at: utc_now()}
+  end
+
   def build(:done_job, attrs) do
     job = build(:job, attrs)
 
-    %{job | done_at: utc_now()}
+    %{job | ended_at: utc_now(), end_status: "success"}
   end
 
   def build(:raising_job, attrs) do


### PR DESCRIPTION
- Updated DB schema: `done_at` field renamed to `ended_at`, added the new `end_status` field. 
- Added DB schema migration (v6) including data migration.
- Added `abort_job` Queuetopia API method

Now, the `ended_at` field is set then Job is somehow completed (successfully or with error or aborted)
The  `abort_job` Queuetopia API method aborts the job whether it is running or not. If job is executing,  'abort_job' brutally terminates the process of job.
